### PR TITLE
Use specific Node.js major version (current latest LTS)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,10 @@
 {
-   "recommendations": [
-       "Orta.vscode-jest",
-       "dbaeumer.vscode-eslint",
-       "streetsidesoftware.code-spell-checker",
-       "esbenp.prettier-vscode"
-   ]
+  "recommendations": [
+    "davidanson.vscode-markdownlint",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "Orta.vscode-jest",
+    "redhat.vscode-yaml",
+    "streetsidesoftware.code-spell-checker"
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "configurations": [
+    {
+      "name": "Run Peblar2MQTT daemon",
+      "request": "launch",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node",
+      "program": "${workspaceFolder}/build/daemon.js",
+      "preLaunchTask": "npm: compile",
+      "outFiles": ["${workspaceFolder}/build/**/*.js"],
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,9 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:lts AS build
+FROM node:22-alpine AS build
 WORKDIR /app
 COPY package*.json .
 COPY *.ts .
@@ -8,7 +8,7 @@ COPY . .
 RUN npm run build
 
 # Containerize
-FROM node:lts
+FROM node:22-alpine
 ENV NODE_ENV=production
 VOLUME /config
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "bin": {
     "peblar2mqtt": "./bin/peblar2mqtt"
   },
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "scripts": {
     "build": "rimraf ./build && npm run compile",
     "start:dev": "npx nodemon",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added recommendations for new extensions: "davidanson.vscode-markdownlint" and "redhat.vscode-yaml".
	- Introduced a new launch configuration for the Peblar2MQTT daemon.
	- Set default formatter for JSON with comments to "esbenp.prettier-vscode".

- **Chores**
	- Updated Dockerfile to use Node.js version 22-alpine.
	- Specified Node.js version requirement in package.json.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->